### PR TITLE
Update token-price-oracles to latest commit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "rxjs-compat": "6.4.0",
     "styled-components": "4.1.3",
     "tidbit": "github:cwhinfrey/tidbit#2995f86f2bb10e667c730ed0807c0e066748e760",
-    "token-price-oracles": "github:levelkdev/token-price-oracles#b0533623de4796fba3cab23ace45710d63579218",
+    "token-price-oracles": "github:levelkdev/token-price-oracles#70441b6d54aa161008500859c8f0118167210601",
     "web3-utils": "1.0.0-beta.50"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm install` was failing for me with something like a "reference is not a tree" referring to `b0533623de4796fba3cab23ace45710d63579218` for token-price-oracles

I think maybe that commit is gone, perhaps because of a force push.  I updated to the latest commit from that repo and then `npm install` worked for me.